### PR TITLE
fixing configuration and its test to match the new namespaces

### DIFF
--- a/lib/configuration.php
+++ b/lib/configuration.php
@@ -82,7 +82,7 @@ class configuration
             'dir' => 'data',
         ),
         'model' => array(
-            'class' => 'privatebin_data',
+            'class' => 'PrivateBin\data\data',
         ),
         'model_options' => array(
             'dir' => 'data',

--- a/tst/configuration.php
+++ b/tst/configuration.php
@@ -128,12 +128,12 @@ class configurationTest extends PHPUnit_Framework_TestCase
         $options['model']['class'] = 'zerobin_data';
         helper::createIniFile(CONF, $options);
         $conf = new configuration;
-        $this->assertEquals('privatebin_data', $conf->getKey('class', 'model'), 'old data class gets renamed');
+        $this->assertEquals('PrivateBin\data\data', $conf->getKey('class', 'model'), 'old data class gets renamed');
 
         $options['model']['class'] = 'zerobin_db';
         helper::createIniFile(CONF, $options);
         $conf = new configuration;
-        $this->assertEquals('privatebin_db', $conf->getKey('class', 'model'), 'old db class gets renamed');
+        $this->assertEquals('PrivateBin\data\db', $conf->getKey('class', 'model'), 'old db class gets renamed');
     }
 
 }


### PR DESCRIPTION
Dear Sobak,

I saw that your branch was failing in some unit tests and thought I could take a look on the this. Its just the renaming of the class in the configuration that caused it.

Good work, all the other tests still succeeded!

Best,
El RIDO
